### PR TITLE
Fix bugs for tower creation

### DIFF
--- a/Bullet.cpp
+++ b/Bullet.cpp
@@ -79,7 +79,7 @@ void Bullet::shot()
 
 void Bullet::attackTarget(Enemy *enemy)
 {
-    if (enemy->getCurrentHealth() - damage > MIN_ENEMY_HEALTH) {
+    if (enemy->getCurrentHealth() - damage > ENEMY_MIN_HEALTH) {
         enemy->setCurrentHealth(enemy->getCurrentHealth() - damage);
     } else {
         enemy->prepareForRemoval();

--- a/Cursor.cpp
+++ b/Cursor.cpp
@@ -89,6 +89,8 @@ bool Cursor::getBuildMode() const
 
 void Cursor::setBuildMode(const bool newBuildMode, const QString &towerType, const qreal scale)
 {
+    buildMode = newBuildMode;
+
     if (newBuildMode) {
 
         if (towerType.isEmpty()) {
@@ -97,7 +99,7 @@ void Cursor::setBuildMode(const bool newBuildMode, const QString &towerType, con
 
         this->towerType = towerType;
 
-        setPixmap(QString(":/Data/Data/Towers/" + towerType + "/Tower.png"));
+        setBuildImage(false);
         QGraphicsPixmapItem::setPos(pos().x() - pixmap().width()/2, pos().y() - pixmap().height()/2);
 
     } else {
@@ -107,8 +109,6 @@ void Cursor::setBuildMode(const bool newBuildMode, const QString &towerType, con
         QGraphicsPixmapItem::setPos(previousPosition);
 
     }
-
-    buildMode = newBuildMode;
 
     setScale(scale);
 }
@@ -164,6 +164,5 @@ void Cursor::setScrollAreaRect(const QRectF &newScrollAreaRect)
 //       procedure won't be called
 void Cursor::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    QGraphicsPixmapItem::mousePressEvent(event);
     emit mousePressed();
 }

--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -13,10 +13,10 @@ Enemy::Enemy(int id,
     id(id),
     type(type),
     route(route),
-    totalHealth(MIN_ENEMY_HEALTH),
-    currentHealth(MIN_ENEMY_HEALTH),
-    speed(MIN_ENEMY_SPEED),
-    stepSize(MIN_ENEMY_SPEED),
+    totalHealth(ENEMY_MIN_HEALTH),
+    currentHealth(ENEMY_MIN_HEALTH),
+    speed(ENEMY_MIN_SPEED),
+    stepSize(ENEMY_MIN_SPEED),
     currentDestinationIndex(0),
     angle(0),
     totalHealthBar(new QGraphicsLineItem),
@@ -76,14 +76,14 @@ void Enemy::loadXmlParameters(QString inFileName)
                                   QString(node.attribute("val")));
 
                 // Prepare total health bar
-                totalHealthBar->setPen(QPen(Qt::red));
+                totalHealthBar->setPen(QPen(QBrush(Qt::red), ENEMY_HEALTH_BAR_WIDTH));
                 totalHealthBar->setLine(pos().x(),
                                         pos().y(),
                                         pos().x() + boundingRect().width() * scale(),
                                         pos().y());
 
                 // Prepare current health bar
-                currentHealthBar->setPen(QPen(Qt::green));
+                currentHealthBar->setPen(QPen(QBrush(Qt::green), ENEMY_HEALTH_BAR_WIDTH));
                 currentHealthBar->setLine(pos().x(),
                                           pos().y(),
                                           pos().x() + boundingRect().width() * scale(),
@@ -155,7 +155,7 @@ int Enemy::getCurrentHealth() const
 
 void Enemy::setCurrentHealth(int newCurrentHealth)
 {
-    currentHealth = (newCurrentHealth < MIN_ENEMY_HEALTH) ? MIN_ENEMY_HEALTH : newCurrentHealth;
+    currentHealth = (newCurrentHealth < ENEMY_MIN_HEALTH) ? ENEMY_MIN_HEALTH : newCurrentHealth;
 
     if(currentHealth < totalHealth) {
         // Decrease current health bar (Green line)
@@ -170,7 +170,7 @@ int Enemy::getTotalHealth() const
 
 void Enemy::setTotalHealth(int newTotalHealth)
 {
-    totalHealth = (newTotalHealth < MIN_ENEMY_HEALTH) ? MIN_ENEMY_HEALTH : newTotalHealth;
+    totalHealth = (newTotalHealth < ENEMY_MIN_HEALTH) ? ENEMY_MIN_HEALTH : newTotalHealth;
 }
 
 void Enemy::show(QGraphicsScene * scene)
@@ -194,7 +194,7 @@ int Enemy::getSpeed() const
 
 void Enemy::setSpeed(int newSpeed)
 {
-    speed = (newSpeed < MIN_ENEMY_SPEED) ? MIN_ENEMY_SPEED : newSpeed;
+    speed = (newSpeed < ENEMY_MIN_SPEED) ? ENEMY_MIN_SPEED : newSpeed;
 
     stepSize = speed * ENEMY_TIMER_INTERVAL / 1000 * scale();
 }

--- a/Enemy.h
+++ b/Enemy.h
@@ -11,8 +11,9 @@
 #include <QRectF>
 
 #define ENEMY_TIMER_INTERVAL 50
-#define MIN_ENEMY_SPEED 20
-#define MIN_ENEMY_HEALTH 1
+#define ENEMY_MIN_SPEED 20
+#define ENEMY_MIN_HEALTH 1
+#define ENEMY_HEALTH_BAR_WIDTH 3
 
 class Enemy : public QObject, public QGraphicsPixmapItem
 {

--- a/GameInterface.cpp
+++ b/GameInterface.cpp
@@ -262,6 +262,11 @@ void GameInterface::processScrollForward()
     currentTowerItem = (currentTowerItem + 1) % towersTypes.size(); // increment until towersTypes.size()
 
     buildTowerItem->setPixmap(QString(":/Data/Data/Towers/" + towersTypes[currentTowerItem] + "/Tower.png"));
+
+    // Set the Icon on the updated position
+    buildTowerItem->setPos(QPointF(
+        playerBoard->x() + playerBoard->boundingRect().width() / 2 - buildTowerItem->boundingRect().width() / 2,
+        playerBoard->y() + playerBoard->boundingRect().height() / 2 - buildTowerItem->boundingRect().height() / 2));
 }
 
 void GameInterface::processScrollBackward()
@@ -269,6 +274,11 @@ void GameInterface::processScrollBackward()
     currentTowerItem = (currentTowerItem > 0 ? currentTowerItem : towersTypes.size()) - 1; // decrement until 0
 
     buildTowerItem->setPixmap(QString(":/Data/Data/Towers/" + towersTypes[currentTowerItem] + "/Tower.png"));
+
+    // Set the Icon on the updated position
+    buildTowerItem->setPos(QPointF(
+        playerBoard->x() + playerBoard->boundingRect().width() / 2 - buildTowerItem->boundingRect().width() / 2,
+        playerBoard->y() + playerBoard->boundingRect().height() / 2 - buildTowerItem->boundingRect().height() / 2));
 }
 
 void GameInterface::processBuildingTower()
@@ -281,7 +291,10 @@ void GameInterface::processBuildingTower()
 
     Tower * tower = new Tower(towersTypes[currentTowerItem], cursor->pos(), battlefield->getLocation());
 
+    // Display the tower on the battlefield
     battlefield->addTower(tower);
+
+    // Display the tower position on the minimap
     minimap->addTower(tower);
 
     disconnect(cursor, &Cursor::mousePressed, this, &GameInterface::processBuildingTower);


### PR DESCRIPTION
* Fixed build on a prohibited area if the cursor did not move immediately after selecting the building mode.
* Fixed Tower Icon positioning after the Arrow click.
* Prevent clicks on menu items in build mode. 
* Health bars have been made thicker.